### PR TITLE
Fixed road access bug; renamed update() methods to simulate()

### DIFF
--- a/src/scripts/assets/assetManager.js
+++ b/src/scripts/assets/assetManager.js
@@ -3,6 +3,7 @@ import viteConfig from '../../../vite.config.js';
 import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js';
 import { Tile } from '../sim/tiles/tile.js';
 import models from './assets.js';
+import { DevelopmentState } from '../sim/buildings/attributes/development.js';
 
 const baseUrl = viteConfig.base;
 const DEG2RAD = Math.PI / 180.0;
@@ -72,11 +73,14 @@ export class AssetManager {
     const zone = tile.building;
 
     let modelName;
-    if (zone.development.state === 'undeveloped' ||
-        zone.development.state === 'under-construction') {
-      modelName = 'under-construction';
-    } else if (zone.development.state === 'developed') {
-      modelName = `${zone.type}-${zone.style}${zone.development.level}`;
+    switch (zone.development.state) {
+      case DevelopmentState.underConstruction,
+           DevelopmentState.undeveloped:
+        modelName = 'under-construction';
+        break;
+      default:
+        modelName = `${zone.type}-${zone.style}${zone.development.level}`;
+        break;
     }
 
     let mesh = this.cloneMesh(modelName);
@@ -85,8 +89,12 @@ export class AssetManager {
     mesh.position.set(zone.x, 0, zone.y);
 
     // Tint building a dark color if it is abandoned
-    if (zone.development.state === 'abandoned') {
-      mesh.material.color = new THREE.Color(0x707070);
+    if (zone.development.state === DevelopmentState.abandoned) {
+      mesh.traverse((obj) => {
+        if (obj.material) {
+          obj.material.color = new THREE.Color(0x707070);
+        }
+      });
     }
     
     return mesh;

--- a/src/scripts/sim/buildings/attributes/development.js
+++ b/src/scripts/sim/buildings/attributes/development.js
@@ -2,13 +2,20 @@ import config from '../../../config.js';
 import { City } from '../../city.js';
 import { Zone } from '../zones/zone.js';
 
+export const DevelopmentState = {
+  abandoned: 'abandoned',
+  developed: 'developed',
+  underConstruction: 'under-construction',
+  undeveloped: 'undeveloped',
+};
+
 export class DevelopmentAttribute {
   #zone;
 
   /**
    * The zone's current state of development
    */
-  #state = 'undeveloped';
+  #state = DevelopmentState.undeveloped;
 
   /**
    * Level of development
@@ -59,28 +66,28 @@ export class DevelopmentAttribute {
   /**
    * @param {City} city 
    */
-  update(city) {
+  simulate(city) {
     this.checkAbandonmentCriteria(city);
 
     switch (this.state) {
-      case 'undeveloped':
+      case DevelopmentState.undeveloped:
         if (this.checkDevelopmentCriteria(city) &&
           Math.random() < config.zone.redevelopChance) {
-          this.state = 'under-construction';
+          this.state = DevelopmentState.underConstruction;
           this.#constructionCounter = 0;
         }
         break;
-      case 'under-construction':
+      case DevelopmentState.underConstruction:
         if (++this.#constructionCounter === config.zone.constructionTime) {
-          this.state = 'developed';
+          this.state = DevelopmentState.developed;
           this.level = 1;
           this.#constructionCounter = 0;
         }
         break;
-      case 'developed':
+      case DevelopmentState.developed:
         if (this.#abandonmentCounter > config.zone.abandonThreshold) {
           if (Math.random() < config.zone.abandonChance) {
-            this.state = 'abandoned';
+            this.state = DevelopmentState.abandoned;
           }
         } else {
           if (this.level < this.maxLevel && Math.random() < config.zone.levelUpChance) {
@@ -88,10 +95,10 @@ export class DevelopmentAttribute {
           }
         }
         break;
-      case 'abandoned':
+      case DevelopmentState.abandoned:
         if (this.#abandonmentCounter == 0) {
           if (Math.random() < config.zone.redevelopChance) {
-            this.state = 'developed';
+            this.state = DevelopmentState.developed;
           }
         }
         break;

--- a/src/scripts/sim/buildings/attributes/jobs.js
+++ b/src/scripts/sim/buildings/attributes/jobs.js
@@ -2,6 +2,7 @@ import config from '../../../config.js';
 import { Citizen } from '../../citizen.js';
 import { City } from '../../city.js';
 import { Zone } from '../zones/zone.js';
+import { DevelopmentState } from './development.js';
 
 export class JobsAttribute {
   /**
@@ -24,8 +25,7 @@ export class JobsAttribute {
    */
   get maxWorkers() {
     // If building is not developed, there are no available jobs
-    if (this.#zone.development.state === 'abandoned' ||
-      this.#zone.development.state === 'undeveloped') {
+    if (this.#zone.development.state === DevelopmentState.developed) {
       return 0;
     } else {
       return Math.pow(config.zone.maxWorkers, this.#zone.development.level);
@@ -52,10 +52,10 @@ export class JobsAttribute {
    * Steps the state of the zone forward in time by one simulation step
    * @param {City} city 
    */
-  update(city) {
+  simulate(city) {
     // If building is abandoned, all workers are laid off and no
     // more workers are allowed to work here
-    if (this.#zone.development.state === 'abandoned') {
+    if (this.#zone.development.state === DevelopmentState.abandoned) {
       this.layOffWorkers();
     }
   }

--- a/src/scripts/sim/buildings/attributes/residents.js
+++ b/src/scripts/sim/buildings/attributes/residents.js
@@ -2,6 +2,7 @@ import config from '../../../config.js';
 import { Citizen } from '../../citizen.js';
 import { City } from '../../city.js';
 import { Zone } from '../zones/zone.js';
+import { DevelopmentState } from './development.js';
 
 export class ResidentsAttribute {
   /**
@@ -40,11 +41,11 @@ export class ResidentsAttribute {
   /**
    * @param {City} city 
    */
-  update(city) {
+  simulate(city) {
     // If building is abandoned, all residents are evicted and no more residents are allowed to move in.
-    if (this.#zone.development.state === 'abandoned' && this.#residents.length > 0) {
+    if (this.#zone.development.state === DevelopmentState.abandoned && this.#residents.length > 0) {
       this.evictAll();
-    } else if (this.#zone.development.state === 'developed') {
+    } else if (this.#zone.development.state === DevelopmentState.developed) {
       // Move in new residents if there is room
       if (this.#residents.length < this.maximum && Math.random() < config.zone.residentMoveInChance) {
         this.#residents.push(new Citizen(this.#zone));

--- a/src/scripts/sim/buildings/building.js
+++ b/src/scripts/sim/buildings/building.js
@@ -39,10 +39,10 @@ export class Building {
   }
 
   /**
-   * Performs a full onMapUpdate of the building state
+   * Performs a full refresh of the building
    * @param {City} city 
    */
-  update(city) {
+  refresh(city) {
   }
 
   /**

--- a/src/scripts/sim/buildings/road.js
+++ b/src/scripts/sim/buildings/road.js
@@ -14,7 +14,7 @@ export class Road extends Building {
    * Updates the road mesh based on which adjacent tiles are roads as well
    * @param {City} city 
    */
-  update(city) {
+  refresh(city) {
     // Check which adjacent tiles are roads
     let top = (city.getTile(this.x, this.y - 1)?.building?.type === this.type) ?? false;
     let bottom = (city.getTile(this.x, this.y + 1)?.building?.type === this.type) ?? false;

--- a/src/scripts/sim/buildings/zones/commercial.js
+++ b/src/scripts/sim/buildings/zones/commercial.js
@@ -21,7 +21,7 @@ export class CommercialZone extends Zone {
    */
   simulate(city) {
     super.simulate(city);
-    this.jobs.update();
+    this.jobs.simulate();
   }
 
   /**

--- a/src/scripts/sim/buildings/zones/industrial.js
+++ b/src/scripts/sim/buildings/zones/industrial.js
@@ -19,7 +19,7 @@ export class IndustrialZone extends Zone {
    */
   simulate(city) {
     super.simulate(city);
-    this.jobs.update();
+    this.jobs.simulate();
   }
 
   /**

--- a/src/scripts/sim/buildings/zones/residential.js
+++ b/src/scripts/sim/buildings/zones/residential.js
@@ -22,7 +22,7 @@ export class ResidentialZone extends Zone {
    */
   simulate(city) {
     super.simulate(city);
-    this.residents.update(city);
+    this.residents.simulate(city);
   }
 
   /**

--- a/src/scripts/sim/buildings/zones/zone.js
+++ b/src/scripts/sim/buildings/zones/zone.js
@@ -22,7 +22,7 @@ export class Zone extends Building {
 
   simulate(city) {
     super.simulate(city);
-    this.development.update(city);
+    this.development.simulate(city);
   }
 
   /**

--- a/src/scripts/sim/city.js
+++ b/src/scripts/sim/city.js
@@ -65,14 +65,14 @@ export class City {
     // If the tile doesnt' already have a building, place one there
     if (tile && !tile.building) {
       tile.building = createBuilding(x, y, buildingType);
-      tile.update(this);
+      tile.refresh(this);
       
       // Update buildings on adjacent tile in case they need to
       // change their mesh (e.g. roads)
-      this.getTile(x - 1, y)?.update(this);
-      this.getTile(x + 1, y)?.update(this);
-      this.getTile(x, y - 1)?.update(this);
-      this.getTile(x, y + 1)?.update(this);
+      this.getTile(x - 1, y)?.refresh(this);
+      this.getTile(x + 1, y)?.refresh(this);
+      this.getTile(x, y - 1)?.refresh(this);
+      this.getTile(x, y + 1)?.refresh(this);
     }
   }
 
@@ -87,12 +87,13 @@ export class City {
     if (tile.building) {
       tile.building.dispose();
       tile.building = null;
+      tile.refresh(this);
 
       // Update neighboring tiles in case they need to change their mesh (e.g. roads)
-      this.getTile(x - 1, y)?.update(this);
-      this.getTile(x + 1, y)?.update(this);
-      this.getTile(x, y - 1)?.update(this);
-      this.getTile(x, y + 1)?.update(this);
+      this.getTile(x - 1, y)?.refresh(this);
+      this.getTile(x + 1, y)?.refresh(this);
+      this.getTile(x, y - 1)?.refresh(this);
+      this.getTile(x, y + 1)?.refresh(this);
     }
   }
 

--- a/src/scripts/sim/tiles/attributes/roadAccess.js
+++ b/src/scripts/sim/tiles/attributes/roadAccess.js
@@ -19,7 +19,7 @@ export class RoadAccessAttribute {
    * Updates the state of this attribute
    * @param {City} city 
    */
-  update(city) {
+  simulate(city) {
     const road = city.findTile(
       this.#tile, 
       (tile) => tile.building?.type === 'road', 

--- a/src/scripts/sim/tiles/tile.js
+++ b/src/scripts/sim/tiles/tile.js
@@ -46,11 +46,10 @@ export class Tile {
   }
 
   /**
-   * Updates the state of the tile and any buildings on it
+   * Performs a full refresh of the tile
    */
-  update(city) {
-    this.roadAccess.update(city);
-    this.building?.update(city);
+  refresh(city) {
+    this.building?.refresh(city);
   }
 
   /**
@@ -58,6 +57,7 @@ export class Tile {
    * @param {*} city 
    */
   simulate(city) {
+    this.roadAccess.simulate(city);
     this.building?.simulate(city);
   }
 

--- a/src/scripts/sim/vehicles/vehicle.js
+++ b/src/scripts/sim/vehicles/vehicle.js
@@ -53,7 +53,7 @@ export class Vehicle extends THREE.Group {
   /**
    * Updates the vehicle position each render frame
    */
-  update() {
+  simulate() {
     if (!this.origin || !this.destination) {
       this.dispose();
       return;

--- a/src/scripts/sim/vehicles/vehicleGraph.js
+++ b/src/scripts/sim/vehicles/vehicleGraph.js
@@ -34,14 +34,14 @@ export class VehicleGraph extends THREE.Group {
       this.tiles.push(column);
     }
 
-    this.helper.update(this);
+    this.helper.refresh(this);
 
     setInterval(this.spawnVehicle.bind(this), config.vehicle.spawnInterval);
   }
 
   updateVehicles() {
     for (const vehicle of this.vehicles.children) {
-      vehicle.update();
+      vehicle.simulate();
     }
   }
 
@@ -93,7 +93,7 @@ export class VehicleGraph extends THREE.Group {
     }
 
     // Update the vehicle graph visualization
-    this.helper.update(this);
+    this.helper.refresh(this);
   }
 
   /**

--- a/src/scripts/sim/vehicles/vehicleGraphHelper.js
+++ b/src/scripts/sim/vehicles/vehicleGraphHelper.js
@@ -21,7 +21,7 @@ export class VehicleGraphHelper extends THREE.Group {
    * 
    * @param {VehicleGraph} graph 
    */
-  update(graph) {
+  refresh(graph) {
     this.clear();
 
     for (let x = 0; x < graph.size; x++) {


### PR DESCRIPTION
- Created an object for enumerating development states
- Renamed all attribute `update()` methods to `simulate()` to make meaning more clear
- Renamed al `update()` methods to `refresh()` to make meaning more clear
- Added missing `tile.refresh()` call when removing a building from a tile